### PR TITLE
Separate GraphiQL directive into its own module

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,12 @@
         {
             "name": "Debug Unit Test",
             "type": "python",
-            "request": "test",
+            "request": "launch",
             "justMyCode": false,
             "env": {
                 "PYTEST_ADDOPTS": "--no-cov"
-            }
-        }
+            },
+            "module": "pytest"
+        }, 
     ]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
     # Adds the inheritance-diagram generation directive
     "sphinx.ext.inheritance_diagram",
     # Adds this library so that we can demo it in the documentation
-    "sphinx_graphql",
+    "sphinx_graphql.graphiql",
 ]
 
 # If true, Sphinx will warn about all references where the target cannot

--- a/docs/tutorials/installation.rst
+++ b/docs/tutorials/installation.rst
@@ -50,7 +50,8 @@ You can check the version that has been installed by typing::
 Including in Sphinx Documentation 
 ---------------------------------
 
-Add the extension to the ``extensions`` list in the ``conf.py`` file for your documentation.
+Add the desired components of extension to the ``extensions`` list in the ``conf.py`` file for your documentation.
+For example:
 
 .. code-block:: python
 
@@ -58,6 +59,6 @@ Add the extension to the ``extensions`` list in the ``conf.py`` file for your do
         # <Preexisting config>
         ...,
         
-        # Utilities for documenting GraphQL APIs
-        "sphinx_graphql",
+        # Directive for embedding GraphiQL view in documentation
+        "sphinx_graphql.graphiql",
     ]

--- a/sphinx_graphql/__init__.py
+++ b/sphinx_graphql/__init__.py
@@ -1,29 +1,3 @@
-import os
-
-from sphinx.util.fileutil import copy_asset
-
 from sphinx_graphql._version_git import __version__
-from sphinx_graphql.graphiql import SphinxGraphiQL
 
 __all__ = ["__version__"]
-
-
-def setup(app):
-    app.add_directive("graphiql", SphinxGraphiQL)
-    app.add_css_file("https://cdn.jsdelivr.net/npm/graphiql@1.0.3/graphiql.css")
-    app.add_js_file(
-        "https://cdn.jsdelivr.net/npm/react@16.13.1/umd/react.production.min.js"
-    )
-    app.add_js_file(
-        "https://cdn.jsdelivr.net/npm/react-dom@16.13.1/umd/react-dom.production.min.js"
-    )
-    app.add_js_file("https://cdn.jsdelivr.net/npm/graphiql@1.0.3/graphiql.min.js")
-    app.add_js_file("attachGraphiQL.js")
-    src = os.path.join(os.path.dirname(__file__), "attachGraphiQL.js")
-    dst = os.path.join(app.outdir, "_static")
-    copy_asset(src, dst)
-    return {
-        "version": "0.1",
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }

--- a/sphinx_graphql/graphiql.py
+++ b/sphinx_graphql/graphiql.py
@@ -1,5 +1,8 @@
+import os
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
+from sphinx.util.fileutil import copy_asset
 
 
 class SphinxGraphiQL(Directive):
@@ -47,3 +50,24 @@ class SphinxGraphiQL(Directive):
             self.lineno
         )
         return [raw_node]
+
+
+def setup(app):
+    app.add_directive("graphiql", SphinxGraphiQL)
+    app.add_css_file("https://cdn.jsdelivr.net/npm/graphiql@1.0.3/graphiql.css")
+    app.add_js_file(
+        "https://cdn.jsdelivr.net/npm/react@16.13.1/umd/react.production.min.js"
+    )
+    app.add_js_file(
+        "https://cdn.jsdelivr.net/npm/react-dom@16.13.1/umd/react-dom.production.min.js"
+    )
+    app.add_js_file("https://cdn.jsdelivr.net/npm/graphiql@1.0.3/graphiql.min.js")
+    app.add_js_file("attachGraphiQL.js")
+    src = os.path.join(os.path.dirname(__file__), "attachGraphiQL.js")
+    dst = os.path.join(app.outdir, "_static")
+    copy_asset(src, dst)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/roots/test-graphiql-live/conf.py
+++ b/tests/roots/test-graphiql-live/conf.py
@@ -1,1 +1,1 @@
-extensions = ["sphinx_graphql"]
+extensions = ["sphinx_graphql.graphiql"]

--- a/tests/roots/test-graphiql/conf.py
+++ b/tests/roots/test-graphiql/conf.py
@@ -1,1 +1,1 @@
-extensions = ["sphinx_graphql"]
+extensions = ["sphinx_graphql.graphiql"]

--- a/tests/test_graphiql.py
+++ b/tests/test_graphiql.py
@@ -8,7 +8,7 @@ from sphinx.testing.util import SphinxTestApp
 def test_build_with_static_graphiql(
     app: SphinxTestApp, status: StringIO, warning: StringIO
 ) -> None:
-    print(f"app: {type(app)}, status: {type(status)}, warning: {type(warning)}")
+    app.warningiserror = True
     app.builder.build_all()
 
 
@@ -16,4 +16,5 @@ def test_build_with_static_graphiql(
 def test_build_with_live_graphiql(
     app: SphinxTestApp, status: StringIO, warning: StringIO
 ) -> None:
+    app.warningiserror = True
     app.builder.build_all()


### PR DESCRIPTION
* Separate GraphiQL directive into its own module that must be included with
```python
extensions = [
    ...,
    "sphinx_graphql.graphiql"
]
```

* Fix tests so that they fail if there are warnings